### PR TITLE
Replace view.then() with view.when()

### DIFF
--- a/src/ts/components/ArcComposites.tsx
+++ b/src/ts/components/ArcComposites.tsx
@@ -46,7 +46,7 @@ export const MapBase = (props: MapBaseProps) => (
                         typedView.on(eventMap[key], props[key]);
                     }
                 });
-                view.then(() => {
+                view.when(() => {
                     resolve({ map, view });
                 }, (err: Error) => {
                     reject(err);

--- a/test/doubles/esriLoader.ts
+++ b/test/doubles/esriLoader.ts
@@ -25,7 +25,7 @@ export function loadModules(modules) {
                     on() {
                         return null;
                     };
-                    then(callback, errback) {
+                    when(callback, errback) {
                         callback();
                     }
                 }
@@ -38,7 +38,7 @@ export function loadModules(modules) {
                     on() {
                         return null;
                     };
-                    then(callback, errback) {
+                    when(callback, errback) {
                         errback( new Error('failed'));
                     }
                 }


### PR DESCRIPTION
Create a new pull request on 3.2.0 branch for the proposed change. Here's the original rational.
--------------------------------------------------------------------------------------------------------------
Since ArcGIS API for JavaScript v4.6, then() is deprecated and when() should be used, to make ArcGIS JavaScript API will be compatible with ES6 Promises.

See https://blogs.esri.com/esri/arcgis/2017/12/14/making-better-promises/ for more details.